### PR TITLE
New specification to be mixed into specs where only one ActorSystem i…

### DIFF
--- a/src/test/scala/uk/gov/homeoffice/akka/ActorSystemContext.scala
+++ b/src/test/scala/uk/gov/homeoffice/akka/ActorSystemContext.scala
@@ -14,13 +14,11 @@ import uk.gov.homeoffice.specs2.ComposableAround
 abstract class ActorSystemContext(val config: Config = ConfigFactory.load) extends TestKitBase with ImplicitSender with Scope with ComposableAround with Logging {
   implicit lazy val system: ActorSystem = ActorSystem(UUID.randomUUID().toString, config)
 
-  override def around[R: AsResult](r: => R): Result = {
-    try {
-      info(s"+ Started actor system $system")
-      super.around(r)
-    } finally {
-      info(s"x Shutting down actor system $system")
-      Await.ready(system.terminate(), 10 seconds)
-    }
+  override def around[R: AsResult](r: => R): Result = try {
+    info(s"+ Started actor system $system")
+    super.around(r)
+  } finally {
+    info(s"x Shutting down actor system $system")
+    Await.ready(system.terminate(), 10 seconds)
   }
 }

--- a/src/test/scala/uk/gov/homeoffice/akka/ActorSystemSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/akka/ActorSystemSpec.scala
@@ -1,0 +1,82 @@
+package uk.gov.homeoffice.akka
+
+import akka.actor.{Actor, Props}
+import org.specs2.mutable.Specification
+
+class ActorSystemSpec extends Specification with ActorSystemSpecification {
+  case object ReactTo
+
+  case object Reacted
+
+  case class AddToState(x: Int)
+
+  case class State(xs: Vector[Int])
+
+  class TestActor extends Actor {
+    var state = Vector.empty[Int]
+
+    override def receive: Receive = {
+      case ReactTo =>
+        sender() ! Reacted
+
+      case AddToState(x) =>
+        state = state :+ x
+        sender() ! State(state)
+
+      case _ =>
+    }
+  }
+
+  "Actor system" should {
+    "be available" in {
+      system actorOf Props { new TestActor }
+      ok
+    }
+  }
+
+  "Actor" should {
+    "not response" in {
+      val actor = system actorOf Props { new TestActor }
+
+      actor ! "Ignore"
+      expectNoMsg
+    }
+
+    "response" in {
+      val actor = system actorOf Props { new TestActor }
+
+      actor ! ReactTo
+      expectMsg(Reacted)
+    }
+  }
+
+  "Actor state for anonymous actor" should {
+    "be unique for an example" in {
+      val actor = system actorOf Props { new TestActor }
+
+      actor ! AddToState(1)
+      expectMsg(State(Vector(1)))
+    }
+
+    "be unique for another example" in {
+      val actor = system actorOf Props { new TestActor }
+
+      actor ! AddToState(2)
+      expectMsg(State(Vector(2)))
+    }
+  }
+
+  "Actor state for named actor" should {
+    val actor = system.actorOf(Props(new TestActor), "named")
+
+    "not be unique for an example" in {
+      actor ! AddToState(1)
+      expectMsg(State(Vector(1)))
+    }
+
+    "not be unique for another example" in {
+      actor ! AddToState(2)
+      expectMsg(State(Vector(1, 2)))
+    }
+  }
+}

--- a/src/test/scala/uk/gov/homeoffice/akka/ActorSystemSpecification.scala
+++ b/src/test/scala/uk/gov/homeoffice/akka/ActorSystemSpecification.scala
@@ -1,0 +1,23 @@
+package uk.gov.homeoffice.akka
+
+import java.util.UUID
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKitBase}
+import org.specs2.execute.Result
+import org.specs2.mutable.SpecificationLike
+import org.specs2.specification.AfterAll
+import com.typesafe.config.{Config, ConfigFactory}
+
+trait ActorSystemSpecification extends TestKitBase with ImplicitSender with AfterAll {
+  this: SpecificationLike =>
+
+  sequential
+
+  implicit lazy val config: Config = ConfigFactory.load
+
+  implicit lazy final val system: ActorSystem = ActorSystem(UUID.randomUUID().toString, config)
+
+  implicit def any2Success[R](r: R): Result = success
+
+  def afterAll() = system.terminate()
+}


### PR DESCRIPTION
…s created for a specification, unlike ActorSystemContext where an ActorSystem is created per example.
